### PR TITLE
Enable Copy/Paste for Gradient Fields

### DIFF
--- a/Runtime/GradientTexture.cs
+++ b/Runtime/GradientTexture.cs
@@ -27,8 +27,8 @@ namespace Packages.GradientTextureGenerator.Runtime
         [SerializeField] Vector2Int _resolution = new Vector2Int(256, 256);
         [SerializeField] bool _sRGB = true;
         [SerializeField] AnimationCurve _verticalLerp = AnimationCurve.Linear(0, 0, 1, 1);
-        [SerializeField, GradientUsage(true)] Gradient _horizontalTop = GetDefaultGradient();
-        [SerializeField, GradientUsage(true)] Gradient _horizontalBottom = GetDefaultGradient();
+        [SerializeField] Gradient _horizontalTop = GetDefaultGradient();
+        [SerializeField] Gradient _horizontalBottom = GetDefaultGradient();
         [SerializeField, HideInInspector] Texture2D _texture = default;
 
         public Texture2D GetTexture() => _texture;


### PR DESCRIPTION
Thanks for the asset it works perfect.
I realized right click -> copy on gradient fields didn't work.

I'm not sure what `GradientUsage(true)` does but it disables right click on gradients.
Removed it and it worked!

https://github.com/mitay-walle/com.mitay-walle.gradient-texture/assets/3739536/6033a9a7-02a6-4ae5-958b-478d83c85cda

